### PR TITLE
Support webpack blocks and variables

### DIFF
--- a/fixtures/module-blocks/package.json
+++ b/fixtures/module-blocks/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "module-blocks",
+  "version": "1.0.0"
+}

--- a/fixtures/module-blocks/src/block.js
+++ b/fixtures/module-blocks/src/block.js
@@ -1,0 +1,5 @@
+var fib = function(n) {
+  return n > 1 ? fib(n - 2) + fib(n - 1) : 1;
+};
+
+module.exports = fib;

--- a/fixtures/module-blocks/src/entry.js
+++ b/fixtures/module-blocks/src/entry.js
@@ -1,0 +1,5 @@
+var fact = function(n) {
+  return n > 0 ? fact(n - 1) + n : 0;
+};
+
+module.exports = fact;

--- a/fixtures/module-blocks/src/entry.test.js
+++ b/fixtures/module-blocks/src/entry.test.js
@@ -1,0 +1,11 @@
+it('async loads', function() {
+  return new Promise(resolve => {
+    require.ensure([], function(require) {
+      resolve(require('./entry'));
+    });
+  })
+  .then(function(entry) {
+    expect(entry).toBeInstanceOf(Function);
+    expect(entry(3)).toBe(6);
+  });
+});

--- a/fixtures/module-blocks/webpack.config.js
+++ b/fixtures/module-blocks/webpack.config.js
@@ -1,0 +1,14 @@
+var join = require('path').join;
+var HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
+
+module.exports = {
+  context: __dirname,
+  entry: './src/entry',
+  output: {
+    path: join(__dirname, 'dist'),
+    filename: '[name].js'
+  },
+  plugins: [
+    new HardSourceWebpackPlugin()
+  ]
+};

--- a/fixtures/module-variables/package.json
+++ b/fixtures/module-variables/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "module-variables",
+  "version": "1.0.0"
+}

--- a/fixtures/module-variables/src/entry.js
+++ b/fixtures/module-variables/src/entry.js
@@ -1,0 +1,1 @@
+module.exports = __resourceQuery;

--- a/fixtures/module-variables/src/entry.test.js
+++ b/fixtures/module-variables/src/entry.test.js
@@ -1,0 +1,10 @@
+if (__resourceQuery) {
+  module.exports = __resourceQuery;
+}
+else {
+  it('has variables', function() {
+    expect(require('./entry?query')).toBe('?query');
+    expect(require('./entry?query2')).toBe('?query2');
+    expect(require('./entry.test?query3')).toBe('?query3');
+  });
+}

--- a/fixtures/module-variables/webpack.config.js
+++ b/fixtures/module-variables/webpack.config.js
@@ -1,0 +1,14 @@
+var join = require('path').join;
+var HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
+
+module.exports = {
+  context: __dirname,
+  entry: './src/entry',
+  output: {
+    path: join(__dirname, 'dist'),
+    filename: '[name].js'
+  },
+  plugins: [
+    new HardSourceWebpackPlugin()
+  ]
+};

--- a/src/entry-reference-module.js
+++ b/src/entry-reference-module.js
@@ -20,11 +20,11 @@ class EntryReferenceModule extends Module {
   }
 
   identifier() {
-    return `entry reference ${this.resource}`;
+    return `entry reference ${this.resource.split('?')[0]}`;
   }
 
   readableIdentifier(requestShortener) {
-    return `entry reference ${requestShortener.shorten(this.resource)}`;
+    return `entry reference ${requestShortener.shorten(this.resource.split('?')[0])}`;
   }
 
   build(options, compilation, resolver, fs, callback) {
@@ -41,7 +41,7 @@ class EntryReferenceModule extends Module {
     const refKeys = {};
     this.dependencies.forEach(dep => {
       if (!dep.module) {return;}
-      if (dep.request.indexOf('!') === -1) {
+      if (dep.request.indexOf('!') === -1 && dep.request.indexOf('?') === -1) {
         if (refKeys.default) {return;}
         refKeys.default = true;
         references.push(`  default: function() {return __webpack_require__(${dep.module.id});}`);
@@ -54,7 +54,10 @@ class EntryReferenceModule extends Module {
     });
     let rawSource = `module.exports = {\n${references.join(',\n')}\n};\n`;
     if (this.isEntry) {
-      const requestHash = this.entryRequest.indexOf('!') === -1 ?
+      const requestHash = (
+        this.entryRequest.indexOf('!') === -1 &&
+        this.entryRequest.indexOf('?') === -1
+      ) ?
         'default' :
         hash(this.entryRequest);
       rawSource += `module.exports[${JSON.stringify(requestHash)}]();\n`;

--- a/src/entry-reference-plugin.js
+++ b/src/entry-reference-plugin.js
@@ -49,11 +49,11 @@ class EntryReferencePlugin {
             return callback(err);
           }
           if (typeof data.source === 'function') {
-            return options.data.compileFile(data.resource, () => {
+            return options.data.compileFile(data.resource.split('?')[0], () => {
               const dep = new EntryReferenceTransformDependency(data.request);
-              dep.userRequest = data.userRequest;
+              // dep.userRequest = data.userRequest;
               dep.module = data;
-              options.data.entries[data.resource].addData(dep);
+              options.data.entries[data.resource.split('?')[0]].addData(dep);
               callback(err, data);
             });
           }
@@ -66,12 +66,12 @@ class EntryReferencePlugin {
             return callback(err, new ExternalModule(data.rawRequest, 'commonjs2'));
           }
 
-          options.data.compileModule(data.request, data.resource, (err, dep) => {
+          options.data.compileModule(data.request, data.resource.split('?')[0], (err, dep) => {
             if (err) {
               return callback(err);
             }
 
-            const shortResource = relative(compilation.compiler.options.context, data.resource);
+            const shortResource = relative(compilation.compiler.options.context, data.resource.split('?')[0]);
             if (compilation.compiler.name === shortResource) {
               callback(null, data);
             }

--- a/src/entry-reference-plugin.test.js
+++ b/src/entry-reference-plugin.test.js
@@ -15,3 +15,17 @@ it('builds multiple versions of a test file', () => {
   .then(utils.itTests(['src/entry.test.js']))
   .then(utils.itPasses);
 }, 30000);
+
+it('builds chunks ensured by a test file', () => {
+  return utils.run('module-blocks')
+  .then(utils.itBuilt(['src/entry.test.js']))
+  .then(utils.itTests(['src/entry.test.js']))
+  .then(utils.itPasses);
+}, 30000);
+
+it('builds variables in a test file', () => {
+  return utils.run('module-variables')
+  .then(utils.itBuilt(['src/entry.test.js']))
+  .then(utils.itTests(['src/entry.test.js']))
+  .then(utils.itPasses);
+}, 30000);

--- a/src/jest-webpack-plugin.js
+++ b/src/jest-webpack-plugin.js
@@ -39,6 +39,7 @@ class JestWebpackPlugin {
     compiler.options.output.path = this.options.path ||
       join(compiler.options.context, '.cache/jest-webpack');
     compiler.options.output.filename = '[name]';
+    compiler.options.output.chunkFilename = '[hash].[id].js';
     // Need an appropriate libraryTarget to get the output from a built module.
     compiler.options.output.libraryTarget = 'commonjs2';
     // Jest is going to require files like in node. The output chunks need to

--- a/src/reference-entry-module.js
+++ b/src/reference-entry-module.js
@@ -21,15 +21,17 @@ class ReferenceEntryModule extends Module {
   }
 
   get requestHash() {
-    return this.data.loaders.length ? hash(this.dep.request) : 'default';
+    return (this.data.loaders.length || this.data.resource.indexOf('?') !== -1) ?
+      hash(this.dep.request) :
+      'default';
   }
 
   identifier() {
-    return `reference ${this.resource}.${this.requestHash}`;
+    return `reference ${this.resource.split('?')[0]}.${this.requestHash}`;
   }
 
   readableIdentifier(requestShortener) {
-    return `reference ${requestShortener.shorten(this.resource)}.${this.requestHash}`;
+    return `reference ${requestShortener.shorten(this.resource.split('?')[0])}.${this.requestHash}`;
   }
 
   build(options, compilation, resolver, fs, callback) {
@@ -39,7 +41,7 @@ class ReferenceEntryModule extends Module {
 
   source() {
     if (!this._source) {
-      let moduleRequire = `require(${JSON.stringify('./' + relative(this.context, this.resource))})`;
+      let moduleRequire = `require(${JSON.stringify('./' + relative(this.context, this.resource.split('?')[0]))})`;
       if (this.isSelfReference) {
         moduleRequire = `__webpack_require__(${this.selfModule.id})`;
         this.dependencies.push(new NullDependency());

--- a/src/shared-data.js
+++ b/src/shared-data.js
@@ -1,4 +1,4 @@
-const {dirname, relative} = require('path');
+const {basename, dirname, join, relative, sep} = require('path');
 
 const NodeTemplatePlugin = require('webpack/lib/node/NodeTemplatePlugin');
 const NodeTargetPlugin = require('webpack/lib/node/NodeTargetPlugin');
@@ -130,6 +130,18 @@ class SharedData {
         new LibraryTemplatePlugin(this.compilation.compiler.options.output.library, this.compilation.compiler.options.output.libraryTarget, this.compilation.compiler.options.output.umdNamedDefine, this.compilation.compiler.options.output.auxiliaryComment || ""),
         {
           apply(compiler) {
+            compiler.plugin('this-compilation', compilation => {
+              compilation.plugin('optimize-assets', (assets, cb) => {
+                Object.keys(assets).forEach(key => {
+                  const newKey = join(dirname(shortResource), basename(key));
+                  if (newKey === key) {return;}
+                  assets[newKey] = assets[key];
+                  delete assets[key];
+                });
+                cb();
+              });
+            });
+
             compiler.plugin('make', (compilation, cb) => {
               // Store compilation to add transforms to later.
               _this.compilations[resource] = compilation;


### PR DESCRIPTION
Blocks made with `import()` and `require.ensure` create chunks to request. Move these chunks to be adjacent to their related compilation entry.

Variables like `__resourceQuery` can implicitly cause multiple versions of a file without different loaders.