### PR TITLE
Store a manifest about the state of the cache

### DIFF
--- a/fixtures/assets-built-plugin.js
+++ b/fixtures/assets-built-plugin.js
@@ -1,0 +1,44 @@
+var tryRequire = function() {
+  var attempts = [].slice.call(arguments);
+  var err;
+  for (var i = 0; i < attempts.length; i++) {
+    var fn = attempts[i];
+    try {
+      return fn();
+    }
+    catch (_) {err = _;}
+  }
+  throw err;
+};
+
+var RawSource = tryRequire(
+  function() {
+    return require('webpack/node_modules/webpack-sources/lib/RawSource');
+  },
+  function() {
+    return require('webpack/node_modules/webpack-core/lib/RawSource');
+  },
+  function() {
+    return require('webpack-sources/lib/RawSource');
+  },
+  function() {
+    return require('webpack-core/lib/RawSource');
+  }
+);
+
+function AssetsBuiltPlugin() {}
+
+AssetsBuiltPlugin.prototype.apply = function(compiler) {
+  compiler.plugin('emit', function(compilation, cb) {
+    try {
+      compilation.assets['built.json'] =
+        new RawSource(JSON.stringify(Object.keys(compilation.assets)));
+    }
+    catch (e) {
+      return cb(e);
+    }
+    cb();
+  });
+};
+
+module.exports = AssetsBuiltPlugin;

--- a/fixtures/cache-blocks-change/package.json
+++ b/fixtures/cache-blocks-change/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "cache-blocks-change",
+  "version": "1.0.0"
+}

--- a/fixtures/cache-blocks-change/src/block.js
+++ b/fixtures/cache-blocks-change/src/block.js
@@ -1,0 +1,5 @@
+var fib = function(n) {
+  return n > 1 ? fib(n - 2) + fib(n - 1) : 1;
+};
+
+module.exports = fib;

--- a/fixtures/cache-blocks-change/src/entry.js
+++ b/fixtures/cache-blocks-change/src/entry.js
@@ -1,0 +1,5 @@
+var fact2 = function(n) {
+  return n > 0 ? fact2(n - 1) + n : 0;
+};
+
+module.exports = fact2;

--- a/fixtures/cache-blocks-change/src/entry.test.js
+++ b/fixtures/cache-blocks-change/src/entry.test.js
@@ -1,0 +1,11 @@
+it('async loads', function() {
+  return new Promise(resolve => {
+    require.ensure([], function(require) {
+      resolve(require('./entry'));
+    });
+  })
+  .then(function(entry) {
+    expect(entry).toBeInstanceOf(Function);
+    expect(entry(3)).toBe(6);
+  });
+});

--- a/fixtures/cache-blocks-change/webpack.config.js
+++ b/fixtures/cache-blocks-change/webpack.config.js
@@ -1,0 +1,17 @@
+var join = require('path').join;
+var HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
+
+var AssetsBuiltPlugin = require('../assets-built-plugin');
+
+module.exports = {
+  context: __dirname,
+  entry: './src/entry',
+  output: {
+    path: join(__dirname, 'dist'),
+    filename: '[name].js'
+  },
+  plugins: [
+    new HardSourceWebpackPlugin(),
+    new AssetsBuiltPlugin(),
+  ]
+};

--- a/fixtures/cache-multiple-loaders-change/package.json
+++ b/fixtures/cache-multiple-loaders-change/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "cache-multiple-loaders-change",
+  "version": "1.0.0"
+}

--- a/fixtures/cache-multiple-loaders-change/src/entry.js
+++ b/fixtures/cache-multiple-loaders-change/src/entry.js
@@ -1,0 +1,5 @@
+var fact = function(n) {
+  return n > 0 ? fact(n - 1) + n : 0;
+};
+
+module.exports = fact;

--- a/fixtures/cache-multiple-loaders-change/src/entry.test.js
+++ b/fixtures/cache-multiple-loaders-change/src/entry.test.js
@@ -1,0 +1,6 @@
+var entry = require("./entry");
+
+it("loads", function() {
+  expect(entry).toBeInstanceOf(Function);
+  expect(entry(3)).toBe(6);
+});

--- a/fixtures/cache-multiple-loaders-change/webpack.config.js
+++ b/fixtures/cache-multiple-loaders-change/webpack.config.js
@@ -1,0 +1,17 @@
+var join = require('path').join;
+var HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
+
+var AssetsBuiltPlugin = require('../assets-built-plugin');
+
+module.exports = {
+  context: __dirname,
+  entry: './src/entry',
+  output: {
+    path: join(__dirname, 'dist'),
+    filename: '[name].js'
+  },
+  plugins: [
+    new HardSourceWebpackPlugin(),
+    new AssetsBuiltPlugin()
+  ]
+};

--- a/fixtures/config-bail/webpack.config.js
+++ b/fixtures/config-bail/webpack.config.js
@@ -1,6 +1,8 @@
 var join = require('path').join;
 var HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 
+var AssetsBuiltPlugin = require('../assets-built-plugin');
+
 module.exports = {
   context: __dirname,
   entry: './src/entry',
@@ -9,6 +11,7 @@ module.exports = {
     filename: '[name].js'
   },
   plugins: [
-    new HardSourceWebpackPlugin()
+    new HardSourceWebpackPlugin(),
+    new AssetsBuiltPlugin()
   ]
 };

--- a/fixtures/config-testMatch/webpack.config.js
+++ b/fixtures/config-testMatch/webpack.config.js
@@ -1,6 +1,8 @@
 var join = require('path').join;
 var HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 
+var AssetsBuiltPlugin = require('../assets-built-plugin');
+
 module.exports = {
   context: __dirname,
   entry: './src/entry',
@@ -9,6 +11,7 @@ module.exports = {
     filename: '[name].js'
   },
   plugins: [
-    new HardSourceWebpackPlugin()
+    new HardSourceWebpackPlugin(),
+    new AssetsBuiltPlugin()
   ]
 };

--- a/fixtures/flags-bail/webpack.config.js
+++ b/fixtures/flags-bail/webpack.config.js
@@ -1,6 +1,8 @@
 var join = require('path').join;
 var HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 
+var AssetsBuiltPlugin = require('../assets-built-plugin');
+
 module.exports = {
   context: __dirname,
   entry: './src/entry',
@@ -9,6 +11,7 @@ module.exports = {
     filename: '[name].js'
   },
   plugins: [
-    new HardSourceWebpackPlugin()
+    new HardSourceWebpackPlugin(),
+    new AssetsBuiltPlugin()
   ]
 };

--- a/fixtures/flags-testMatch/webpack.config.js
+++ b/fixtures/flags-testMatch/webpack.config.js
@@ -1,6 +1,8 @@
 var join = require('path').join;
 var HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 
+var AssetsBuiltPlugin = require('../assets-built-plugin');
+
 module.exports = {
   context: __dirname,
   entry: './src/entry',
@@ -9,6 +11,7 @@ module.exports = {
     filename: '[name].js'
   },
   plugins: [
-    new HardSourceWebpackPlugin()
+    new HardSourceWebpackPlugin(),
+    new AssetsBuiltPlugin()
   ]
 };

--- a/fixtures/flags-testNamePattern/webpack.config.js
+++ b/fixtures/flags-testNamePattern/webpack.config.js
@@ -1,6 +1,8 @@
 var join = require('path').join;
 var HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 
+var AssetsBuiltPlugin = require('../assets-built-plugin');
+
 module.exports = {
   context: __dirname,
   entry: './src/entry',
@@ -9,6 +11,7 @@ module.exports = {
     filename: '[name].js'
   },
   plugins: [
-    new HardSourceWebpackPlugin()
+    new HardSourceWebpackPlugin(),
+    new AssetsBuiltPlugin()
   ]
 };

--- a/fixtures/flags-testPathPattern/webpack.config.js
+++ b/fixtures/flags-testPathPattern/webpack.config.js
@@ -1,6 +1,8 @@
 var join = require('path').join;
 var HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 
+var AssetsBuiltPlugin = require('../assets-built-plugin');
+
 module.exports = {
   context: __dirname,
   entry: './src/entry',
@@ -9,6 +11,7 @@ module.exports = {
     filename: '[name].js'
   },
   plugins: [
-    new HardSourceWebpackPlugin()
+    new HardSourceWebpackPlugin(),
+    new AssetsBuiltPlugin()
   ]
 };

--- a/fixtures/flags-testRegex/webpack.config.js
+++ b/fixtures/flags-testRegex/webpack.config.js
@@ -1,6 +1,8 @@
 var join = require('path').join;
 var HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 
+var AssetsBuiltPlugin = require('../assets-built-plugin');
+
 module.exports = {
   context: __dirname,
   entry: './src/entry',
@@ -9,6 +11,7 @@ module.exports = {
     filename: '[name].js'
   },
   plugins: [
-    new HardSourceWebpackPlugin()
+    new HardSourceWebpackPlugin(),
+    new AssetsBuiltPlugin()
   ]
 };

--- a/fixtures/module-blocks/webpack.config.js
+++ b/fixtures/module-blocks/webpack.config.js
@@ -1,6 +1,8 @@
 var join = require('path').join;
 var HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 
+var AssetsBuiltPlugin = require('../assets-built-plugin');
+
 module.exports = {
   context: __dirname,
   entry: './src/entry',
@@ -9,6 +11,7 @@ module.exports = {
     filename: '[name].js'
   },
   plugins: [
-    new HardSourceWebpackPlugin()
+    new HardSourceWebpackPlugin(),
+    new AssetsBuiltPlugin()
   ]
 };

--- a/fixtures/module-multiple-loaders-test/webpack.config.js
+++ b/fixtures/module-multiple-loaders-test/webpack.config.js
@@ -1,6 +1,8 @@
 var join = require('path').join;
 var HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 
+var AssetsBuiltPlugin = require('../assets-built-plugin');
+
 module.exports = {
   context: __dirname,
   entry: './src/entry',
@@ -9,6 +11,7 @@ module.exports = {
     filename: '[name].js'
   },
   plugins: [
-    new HardSourceWebpackPlugin()
+    new HardSourceWebpackPlugin(),
+    new AssetsBuiltPlugin()
   ]
 };

--- a/fixtures/module-multiple-loaders/webpack.config.js
+++ b/fixtures/module-multiple-loaders/webpack.config.js
@@ -1,6 +1,8 @@
 var join = require('path').join;
 var HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 
+var AssetsBuiltPlugin = require('../assets-built-plugin');
+
 module.exports = {
   context: __dirname,
   entry: './src/entry',
@@ -9,6 +11,7 @@ module.exports = {
     filename: '[name].js'
   },
   plugins: [
-    new HardSourceWebpackPlugin()
+    new HardSourceWebpackPlugin(),
+    new AssetsBuiltPlugin()
   ]
 };

--- a/fixtures/module-variables/webpack.config.js
+++ b/fixtures/module-variables/webpack.config.js
@@ -1,6 +1,8 @@
 var join = require('path').join;
 var HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 
+var AssetsBuiltPlugin = require('../assets-built-plugin');
+
 module.exports = {
   context: __dirname,
   entry: './src/entry',
@@ -9,6 +11,7 @@ module.exports = {
     filename: '[name].js'
   },
   plugins: [
-    new HardSourceWebpackPlugin()
+    new HardSourceWebpackPlugin(),
+    new AssetsBuiltPlugin()
   ]
 };

--- a/fixtures/test-entries-src-babel/webpack.config.babel.js
+++ b/fixtures/test-entries-src-babel/webpack.config.babel.js
@@ -1,6 +1,8 @@
 const {join} = require('path');
 var HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 
+var AssetsBuiltPlugin = require('../assets-built-plugin');
+
 module.exports = {
   context: __dirname,
   entry: './src/entry',
@@ -9,6 +11,7 @@ module.exports = {
     filename: '[name].js',
   },
   plugins: [
-    new HardSourceWebpackPlugin()
+    new HardSourceWebpackPlugin(),
+    new AssetsBuiltPlugin()
   ]
 };

--- a/fixtures/test-entries-src/webpack.config.js
+++ b/fixtures/test-entries-src/webpack.config.js
@@ -1,6 +1,8 @@
 var join = require('path').join;
 var HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 
+var AssetsBuiltPlugin = require('../assets-built-plugin');
+
 module.exports = {
   context: __dirname,
   entry: './src/entry',
@@ -9,6 +11,7 @@ module.exports = {
     filename: '[name].js'
   },
   plugins: [
-    new HardSourceWebpackPlugin()
+    new HardSourceWebpackPlugin(),
+    new AssetsBuiltPlugin()
   ]
 };

--- a/fixtures/utils.js
+++ b/fixtures/utils.js
@@ -74,10 +74,22 @@ const run = async (fixturePath, args = []) => {
   const stdout = concat(child.stdout);
   const stderr = concat(child.stderr);
   const exit = new Promise(resolve => child.on('exit', resolve));
+  // const built = exit
+  // .then(() => walkDir(fullJestWebpackPath, fullJestWebpackPath));
   const built = exit
-  .then(() => walkDir(fullJestWebpackPath, fullJestWebpackPath));
+  .then(() => pify(fs.readFile)(join(fullJestWebpackPath, 'built.json'), 'utf8'))
+  .then(JSON.parse);
 
   return Promise.all([stdout, stderr, exit, built])
+  .catch(err => {
+    console.error(err);
+    return Promise.all([stdout, stderr])
+    .then(([stdout, stderr]) => {
+      console.error(stdout);
+      console.error(stderr);
+      throw err;
+    });
+  })
   .then(([stdout, stderr, exit, built]) => {
     return {
       exit,

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "file-loader": "^0.11.2",
     "hard-source-webpack-plugin": "^0.4.4",
     "jest": "^20.0.4",
-    "node-object-hash": "^1.2.0",
     "raw-loader": "^0.5.1",
     "rimraf": "^2.6.1",
     "source-map-support": "^0.4.15",
@@ -48,6 +47,8 @@
   },
   "dependencies": {
     "find-up": "^2.1.0",
+    "node-object-hash": "^1.2.0",
+    "pify": "^3.0.0",
     "regenerator-runtime": "^0.10.5",
     "webpack-sources": "^1.0.1"
   },

--- a/src/emit-changed-assets-plugin.js
+++ b/src/emit-changed-assets-plugin.js
@@ -9,56 +9,6 @@ class EmitChangedAssetsPlugin {
   apply(compiler) {
     const config = compiler.options;
 
-    // // Create assets for original source files that changed.
-    // compiler.plugin('emit', function(compilation, cb) {
-    //   const originals = {};
-    //   const context = compiler.options.context;
-    //   compilation.modules.forEach(module => {
-    //     if (!module.resource) {return;}
-    //     const resource = module.resource;
-    //     let name = relative(context, resource);
-    //     if (module.reasons[0] && module.reasons[0].dependency.loc) {
-    //       name = module.reasons[0].dependency.loc;
-    //     }
-    //     if (module.name) {
-    //       name = module.name;
-    //     }
-    //     if (typeof name === 'string' && resource && !originals[name]) {
-    //       originals[name] = resource;
-    //     }
-    //   });
-    //
-    //   Object.entries(originals).forEach(([name, original]) => {
-    //     const assetPath = join('original', name);
-    //     compilation.assets[assetPath] = new RawSource(readFileSync(original));
-    //   });
-    //
-    //   cb();
-    // });
-
-    compiler.plugin('emit', function(compilation, cb) {
-      try {
-        compilation.assets['package.json'] =
-          new RawSource(readFileSync(join(config.context, 'package.json')));
-      }
-      catch (err) {
-        return cb(err);
-      }
-      cb();
-    });
-
-    // compiler.plugin('emit', function(compilation, cb) {
-    //   Object.keys(compilation.assets).forEach(function(key) {
-    //     if (/\.map$/.test(key) && /^webpack/.test(key)) {
-    //       const originalPath = join('original', relative('webpack', key));
-    //       if (!compilation.assets[originalPath]) {
-    //         compilation.assets[originalPath] = compilation.assets[key];
-    //       }
-    //     }
-    //   });
-    //   cb();
-    // });
-
     // Don't emit files that were already written correctly. That'll cause jest
     // to run them again.
     compiler.plugin('emit', function(compilation, cb) {

--- a/src/emit-package-plugin.js
+++ b/src/emit-package-plugin.js
@@ -1,0 +1,25 @@
+const {join, relative, resolve} = require('path');
+
+const pify = require('pify');
+const RawSource = require('webpack-sources/lib/RawSource');
+
+const hash = require('./hash');
+
+class EmitPackagePlugin {
+  apply(compiler) {
+    const config = compiler.options;
+
+    compiler.plugin('make', (compilation, cb) => {
+      const inputFileSystem = compilation.inputFileSystem;
+      const readFile = inputFileSystem.readFile.bind(inputFileSystem);
+      pify(readFile)(join(config.context, 'package.json'))
+      .then(src => {
+        compilation.assets['package.json'] = new RawSource(src);
+        cb();
+      })
+      .catch(cb);
+    });
+  }
+}
+
+module.exports = EmitPackagePlugin;

--- a/src/entry-reference-plugin.js
+++ b/src/entry-reference-plugin.js
@@ -50,7 +50,7 @@ class EntryReferencePlugin {
           }
           if (typeof data.source === 'function') {
             return options.data.compileFile(data.resource.split('?')[0], () => {
-              const dep = new EntryReferenceTransformDependency(data.request);
+              const dep = new EntryReferenceTransformDependency('!!' + data.request);
               // dep.userRequest = data.userRequest;
               dep.module = data;
               options.data.entries[data.resource.split('?')[0]].addData(dep);

--- a/src/file-hash.js
+++ b/src/file-hash.js
@@ -1,0 +1,47 @@
+const {join} = require('path');
+const {readdir, readFile, stat} = require('fs');
+
+const pify = require('pify');
+const nodeObjectHash = require('node-object-hash');
+
+const hash = require('./hash');
+
+const fileHash = file => pify(readFile)(file).then(hash);
+
+const contextHash = (dir, _contextHash = contextHash) => {
+  return pify(readdir)(dir)
+  .then(names => {
+    return Promise.all(names.map(name => {
+      const fullpath = join(dir, name);
+      return pify(stat)(fullpath)
+      .then(stat => {
+        if (stat.isDirectory()) {
+          return _contextHash(fullpath);
+        }
+        else {
+          return fileHash(fullpath);
+        }
+      });
+    }));
+  })
+  .then(hashes => hashes.reduce((carry, value) => hash(carry + value)));
+};
+
+const depsContextHash = dir => {
+  return contextHash(dir, dir => (
+    pify(stat)(join(dir, 'package.json'))
+    .then(() => fileHash(join(dir, 'package.json')))
+    .catch(() => contextHash(dir, dir => hash(dir)))
+  ));
+};
+
+const configHash = config => {
+  return nodeObjectHash({sort: false}).hash(config);
+};
+
+module.exports = {
+  configHash,
+  contextHash,
+  depsContextHash,
+  fileHash,
+};

--- a/src/jest-webpack-plugin.js
+++ b/src/jest-webpack-plugin.js
@@ -1,6 +1,7 @@
 const {join} = require('path');
 
 const EmitChangedAssetsPlugin = require('./emit-changed-assets-plugin');
+const EmitPackagePlugin = require('./emit-package-plugin');
 const EntryPerModulePlugin = require('./entry-per-module-plugin');
 const EntryReferencePlugin = require('./entry-reference-plugin');
 const RunJestWhenDonePlugin = require('./run-jest-when-done-plugin');
@@ -49,6 +50,7 @@ class JestWebpackPlugin {
 
     const shared = new SharedData();
 
+    new EmitPackagePlugin().apply(compiler);
     new EmitChangedAssetsPlugin().apply(compiler);
     new EntryReferencePlugin({data: shared}).apply(compiler);
     // this.entryPerModule = new EntryPerModulePlugin();

--- a/src/jest-webpack-plugin.js
+++ b/src/jest-webpack-plugin.js
@@ -4,6 +4,7 @@ const EmitChangedAssetsPlugin = require('./emit-changed-assets-plugin');
 const EmitPackagePlugin = require('./emit-package-plugin');
 const EntryPerModulePlugin = require('./entry-per-module-plugin');
 const EntryReferencePlugin = require('./entry-reference-plugin');
+const ManifestPlugin = require('./manifest-plugin');
 const RunJestWhenDonePlugin = require('./run-jest-when-done-plugin');
 const SharedData = require('./shared-data');
 const TestEntriesPlugin = require('./test-entries-plugin');
@@ -52,6 +53,7 @@ class JestWebpackPlugin {
 
     new EmitPackagePlugin().apply(compiler);
     new EmitChangedAssetsPlugin().apply(compiler);
+    new ManifestPlugin({data: shared}).apply(compiler);
     new EntryReferencePlugin({data: shared}).apply(compiler);
     // this.entryPerModule = new EntryPerModulePlugin();
     // this.entryPerModule.apply(compiler);

--- a/src/manifest-plugin.js
+++ b/src/manifest-plugin.js
@@ -1,0 +1,174 @@
+const {join} = require('path');
+
+const pify = require('pify');
+const RawSource = require('webpack-sources/lib/RawSource');
+
+const hash = require('./hash');
+const ReferenceEntryModule = require('./reference-entry-module');
+const {configHash, contextHash, depsContextHash, fileHash} =
+  require('./file-hash');
+
+const hashMembers = (members, memberHash) => {
+  return Promise.all(members.map(memberHash))
+    .then(hashes => hashes.reduce((carry, value) => hash(carry + value), ''));
+};
+
+class ManifestPlugin {
+  constructor(options = {}) {
+    this.options = options;
+  }
+
+  apply(compiler) {
+    const options = this.options;
+    const _configHash = configHash(compiler.options);
+
+    const manifestPath = join(compiler.options.context, '.cache/jest-webpack/manifest.json');
+    const depsDirs = [join(compiler.options.context, 'node_modules')];
+
+    compiler.plugin(['watch-run', 'run'], (compiler, cb) => {
+      const inputFileSystem = compiler.inputFileSystem;
+      const readFile = inputFileSystem.readFile.bind(inputFileSystem);
+      const manifest = pify(readFile)(manifestPath)
+      .then(file => file.toString())
+      .catch(() => '{}')
+      .then(JSON.parse);
+      const depsHash = Promise.all(depsDirs.map(depsContextHash))
+      .then(hashes => hashes.reduce((carry, value) => hash(carry + value)));
+      Promise.all([manifest, depsHash])
+      .then(([manifest, depsHash]) => {
+        return Promise.all(
+          Object.keys(manifest)
+          .filter(resource => !resource.startsWith('__'))
+          .map(resource => {
+            return Promise.all([
+              pify(readFile)(join(compiler.options.context, '.cache/jest-webpack', resource))
+              .then(hash)
+              .catch(() => ''),
+              hashMembers(manifest[resource].fileDependencies, fileHash),
+              hashMembers(manifest[resource].contextDependencies, contextHash),
+            ])
+            .then(([hash, fileHash, contextHash]) => {
+              if (
+                manifest[resource].hash === hash &&
+                manifest[resource].fileHash === fileHash &&
+                manifest[resource].contextHash === contextHash
+              ) {
+                return {
+                  resource: join(compiler.options.context, resource),
+                  transforms: manifest[resource].transforms,
+                };
+              }
+            });
+          })
+        )
+        .then(entries => entries.filter(Boolean))
+        .then(entries => {
+          const _manifest = {
+            __depsHash: manifest.__depsHash,
+            __configHash: manifest.__configHash,
+          };
+          entries.forEach(entry => {
+            _manifest[entry.resource] = entry;
+          });
+          return [_manifest, depsHash];
+        });
+      })
+      .then(([manifest, depsHash]) => {
+        if (
+          manifest.__depsHash !== depsHash ||
+          manifest.__configHash !== _configHash
+        ) {
+          options.data.setManifest(null);
+          return cb();
+        }
+
+        // console.log(manifest);
+        // process.exit();
+        options.data.setManifest(manifest);
+        cb();
+      })
+      .catch(err => {console.error(err); throw err;})
+      .catch(cb);
+    });
+
+    compiler.plugin('emit', (compilation, cb) => {
+      const inputFileSystem = compilation.inputFileSystem;
+      const readFile = inputFileSystem.readFile.bind(inputFileSystem);
+      pify(readFile)(manifestPath)
+      .then(file => file.toString())
+      .catch(() => '{}')
+      .then(JSON.parse)
+      .then(manifest => {
+        return Promise.all(compilation.children.map(fileCompilation => {
+          const source =
+            fileCompilation.assets[fileCompilation.compiler.name].source();
+          return Promise.all([
+            Promise.resolve(source)
+            .then(hash)
+            .catch(() => ''),
+            hashMembers(fileCompilation.fileDependencies, fileHash),
+            hashMembers(fileCompilation.contextDependencies, contextHash),
+          ])
+          .then(([hash, fileHash, contextHash]) => {
+            // console.log('new version', fileCompilation.compiler.name, hash);
+            const listDepRequests = block => (
+              block.dependencies
+                .map(dep => dep.module instanceof ReferenceEntryModule ?
+                  dep.module.dep.request :
+                  null)
+                .filter(Boolean)
+            );
+            const listVarRequests = block => (
+              block.variables.map(listDepRequests)
+            );
+            const listBlkRequests = block => (
+              listDepRequests(block)
+              .concat(...listVarRequests(block))
+              .concat(...block.blocks.map(listBlkRequests))
+            );
+            manifest[fileCompilation.compiler.name] = {
+              fileDependencies: fileCompilation.fileDependencies,
+              contextDependencies: fileCompilation.contextDependencies,
+              hash,
+              fileHash,
+              contextHash,
+              transforms: fileCompilation.modules
+              .find(module => module.identifier().startsWith("entry reference"))
+              .dependencies
+              .reduce((carry, dep) => {
+                if (!carry.find(_dep => _dep.module.request === dep.module.request)) {
+                  carry.push(dep);
+                }
+                return carry;
+              }, [])
+              .map(dep => ({
+                isEntry: !dep.module.rawRequest.startsWith('!!'),
+                request: dep.module.request,
+                rawRequest: dep.module.rawRequest,
+                dependencies: listBlkRequests(dep.module)
+                  .reduce((carry, dep) => {
+                    if (carry.indexOf(dep) === -1) {
+                      carry.push(dep);
+                    }
+                    return carry;
+                  }, []),
+              })),
+            };
+          });
+        }))
+        .then(() => (
+          depsContextHash(join(compiler.options.context, 'node_modules'))
+        ))
+        .then(depsHash => {
+          manifest.__configHash = _configHash;
+          manifest.__depsHash = depsHash;
+          compilation.assets['manifest.json'] = new RawSource(JSON.stringify(manifest));
+        });
+      })
+      .then(() => cb())
+      .catch(cb);;
+    });
+  }
+}
+
+module.exports = ManifestPlugin;

--- a/src/manifest-plugin.test.js
+++ b/src/manifest-plugin.test.js
@@ -1,0 +1,93 @@
+// require('source-map-support').install({hookRequire: true});
+
+const utils = require('../fixtures/utils');
+
+const itCaches = (fixture, file) => {
+  it(`caches "${fixture}"`, () => {
+    return utils.run(fixture)
+    .then(utils.itBuilt([file]))
+    .then(utils.itTests([file]))
+    .then(utils.itPasses)
+    .then(utils.runAgain)
+    .then(utils.didNotBuild([file]))
+    .then(utils.itTests([file]))
+    .then(utils.itPasses);
+  }, 30000);
+};
+
+const itCachesChange = (fixture, {built, notBuilt, tests, filesA, filesB}) => {
+  it(`caches and builds changes "${fixture}"`, () => {
+    return utils.willRun(fixture)
+    .then(utils.clean)
+    .then(utils.writeFiles(filesA))
+    .then(utils.runAgain)
+    .then(utils.itBuilt([built, notBuilt].filter(Boolean)))
+    .then(utils.itTests([tests].filter(Boolean)))
+    .then(utils.itPasses)
+    .then(utils.writeFiles(filesB))
+    .then(utils.runAgain)
+    .then(utils.itBuilt([built].filter(Boolean)))
+    .then(utils.didNotBuild([notBuilt].filter(Boolean)))
+    .then(utils.itTests([tests].filter(Boolean)))
+    .then(utils.itPasses);
+  }, 30000);
+};
+
+itCaches('module-blocks', 'src/entry.test.js');
+itCaches('module-multiple-loaders', 'src/entry.test.js');
+itCaches('module-multiple-loaders-test', 'src/entry.test.js');
+itCaches('module-variables', 'src/entry.test.js');
+itCaches('test-entries-src', 'src/entry.test.js');
+itCaches('test-entries-src-babel', 'src/entry.test.js');
+
+itCachesChange('cache-blocks-change', {
+  built: 'src/entry.js',
+  notBuilt: 'src/entry.test.js',
+  tests: 'src/entry.test.js',
+  filesA: {
+    'src/entry.js': [
+      'var fact = function(n) {',
+      '  return n > 0 ? fact(n - 1) + n : 0;',
+      '};',
+      '',
+      'module.exports = fact;',
+    ],
+  },
+  filesB: {
+    'src/entry.js': [
+      'var fact2 = function(n) {',
+      '  return n > 0 ? fact2(n - 1) + n : 0;',
+      '};',
+      '',
+      'module.exports = fact2;',
+    ],
+  },
+});
+
+itCachesChange('cache-multiple-loaders-change', {
+  built: 'src/entry.js',
+  tests: 'src/entry.test.js',
+  filesA: {
+    'src/entry.test.js': [
+      'var entry = require("./entry");',
+      'var rawEntry = require("raw-loader!./entry");',
+      '',
+      'it("loads", function() {',
+      '  expect(entry).toBeInstanceOf(Function);',
+      '  expect(entry(3)).toBe(6);',
+      '  expect(typeof rawEntry).toBe("string");',
+      '  expect(rawEntry).toMatch("var fact");',
+      '});',
+    ],
+  },
+  filesB: {
+    'src/entry.test.js': [
+      'var entry = require("./entry");',
+      '',
+      'it("loads", function() {',
+      '  expect(entry).toBeInstanceOf(Function);',
+      '  expect(entry(3)).toBe(6);',
+      '});',
+    ],
+  },
+});

--- a/src/test-entries-plugin.js
+++ b/src/test-entries-plugin.js
@@ -75,6 +75,10 @@ class TestEntriesPlugin {
           const entry = resolve(compiler.options.context, name);
           options.data.compileModule(entry, entry, () => {}, true);
         });
+
+        if (options.data.filesRunning === 0) {
+          cb();
+        }
       })
       .catch(cb);
     });

--- a/src/test-entries-plugin.js
+++ b/src/test-entries-plugin.js
@@ -1,5 +1,5 @@
 const {readFileSync} = require('fs');
-const {resolve} = require('path');
+const {resolve, sep} = require('path');
 
 const SingleEntryDependency = require('webpack/lib/dependencies/SingleEntryDependency');
 const SingleEntryPlugin = require('webpack/lib/SingleEntryPlugin');
@@ -45,12 +45,15 @@ class TestEntriesPlugin {
     compiler.plugin('make', (compilation, cb) => {
       const {jestArgv, jestConfig} = options;
 
+      const ignoreCacheJestWebpack =
+        '/.cache/jest-webpack/'.replace(/\//g, sep === '\\' ? '\\\\' : sep);
+
       const configIgnoreJestWebpack = Object.assign({}, jestConfig.config, {
         modulePathIgnorePatterns:
           (jestConfig.config.modulePathIgnorePatterns || [])
-          .concat(['/.cache/jest-webpack/']),
+          .concat([ignoreCacheJestWebpack]),
         testPathIgnorePatterns: jestConfig.config.testPathIgnorePatterns
-          .concat(['/.cache/jest-webpack/']),
+          .concat([ignoreCacheJestWebpack]),
       });
 
       try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2564,6 +2564,10 @@ pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
 
+pify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
+
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"


### PR DESCRIPTION
Store a manifest with the files compiled, the hashes of their dependencies, the requests and dependencies of those requests. Load that manifest during the next build and creating updated hashes determine which files may not need to be rebuilt. When considering modules that are already recorded in the manifest start the dependencies recorded for that module to make sure all files are considered. If a new transform of a file is to be built, content of the manifest for that file no longer matters, it needs to be built to include the new transform. If a transform is no longer needed the file should still be rebuilt to keep the built cache close to the original files needs.