### PR TITLE
Reuse deps hash

### DIFF
--- a/src/file-hash.js
+++ b/src/file-hash.js
@@ -1,4 +1,4 @@
-const {join} = require('path');
+const {basename, join} = require('path');
 const {readdir, readFile, stat} = require('fs');
 
 const pify = require('pify');
@@ -24,14 +24,17 @@ const contextHash = (dir, _contextHash = contextHash) => {
       });
     }));
   })
+  .then(hashes => hashes.filter(Boolean))
   .then(hashes => hashes.reduce((carry, value) => hash(carry + value)));
 };
 
 const depsContextHash = dir => {
   return contextHash(dir, dir => (
-    pify(stat)(join(dir, 'package.json'))
-    .then(() => fileHash(join(dir, 'package.json')))
-    .catch(() => contextHash(dir, dir => hash(dir)))
+    basename(dir).startsWith('.') ?
+      null :
+      pify(stat)(join(dir, 'package.json'))
+      .then(() => fileHash(join(dir, 'package.json')))
+      .catch(() => contextHash(dir, dir => hash(dir)))
   ));
 };
 

--- a/src/jest-webpack-plugin.js
+++ b/src/jest-webpack-plugin.js
@@ -1,8 +1,8 @@
 const {join} = require('path');
 
-const EmitChangedAssetsPlugin = require('./emit-changed-assets-plugin');
+// const EmitChangedAssetsPlugin = require('./emit-changed-assets-plugin');
 const EmitPackagePlugin = require('./emit-package-plugin');
-const EntryPerModulePlugin = require('./entry-per-module-plugin');
+// const EntryPerModulePlugin = require('./entry-per-module-plugin');
 const EntryReferencePlugin = require('./entry-reference-plugin');
 const ManifestPlugin = require('./manifest-plugin');
 const RunJestWhenDonePlugin = require('./run-jest-when-done-plugin');
@@ -52,7 +52,7 @@ class JestWebpackPlugin {
     const shared = new SharedData();
 
     new EmitPackagePlugin().apply(compiler);
-    new EmitChangedAssetsPlugin().apply(compiler);
+    // new EmitChangedAssetsPlugin().apply(compiler);
     new ManifestPlugin({data: shared}).apply(compiler);
     new EntryReferencePlugin({data: shared}).apply(compiler);
     // this.entryPerModule = new EntryPerModulePlugin();


### PR DESCRIPTION
Build the deps hash once. This saves time when emitting or in watch
mode. A user should not change their dependencies while the build
system is running.