### PR TITLE
Improve speed of testing jest-webpack

### DIFF
--- a/fixtures/.babelrc
+++ b/fixtures/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": [["env", {"targets": {"node": 4}}]]
+}

--- a/fixtures/worker.babel.js
+++ b/fixtures/worker.babel.js
@@ -1,0 +1,17 @@
+var join = require('path').join;
+var readFileSync = require('fs').readFileSync;
+
+var babel = require('babel-core');
+
+try {
+  var code = babel.transform(
+    readFileSync(join(__dirname, 'worker.js'), 'utf8'),
+    {presets: [['env', {targets: {node: 4}}]]}
+  ).code;
+}
+catch (err) {
+  console.error(err.stack || err);
+  throw err;
+}
+
+eval(code);

--- a/fixtures/worker.js
+++ b/fixtures/worker.js
@@ -1,0 +1,82 @@
+const {dirname, join} = require('path');
+const {readFileSync, statSync} = require('fs');
+const {runInThisContext} = require('vm');
+
+const {transform} = require('babel-core');
+const findUp = require('find-up');
+
+const jestWebpackPath = findUp.sync('jest-webpack.js');
+const fixtureRootPath = join(dirname(jestWebpackPath), 'fixtures');
+
+const jestWebpack = eval('require')(jestWebpackPath);
+
+const wrapModule = code => {
+  return '(function(exports, require, module, __filename, __dirname) {' +
+    code +
+  '})';
+};
+
+const callModule = (fn, filename) => {
+  const module = {exports: {}};
+  fn(module.exports, Object.assign(modulename => {
+    if (/\W/.test(modulename[0])) {
+      return eval('require')(join(dirname(filename), modulename));
+    }
+    return eval('require')(modulename);
+  }, eval('require')), module, filename, dirname(filename));
+  return module.exports;
+};
+
+const loadFreshConfig = configPath => {
+  try {
+    try {
+      return callModule(runInThisContext(
+        wrapModule(readFileSync(configPath, 'utf8')),
+        {filename: configPath}
+      ), configPath)
+    }
+    catch (_) {
+      return callModule(runInThisContext(
+        wrapModule(transform(readFileSync(configPath, 'utf8'), {presets: [['env', {targets: {node: 4}}]]}).code),
+        {filename: configPath}
+      ), configPath)
+    }
+  }
+  catch (err) {
+    console.error(err.stack || err);
+    throw err;
+  }
+};
+
+const fixtureWebpackConfigPath = fixture => {
+  try {
+    statSync(join(fixtureRootPath, fixture, 'webpack.config.babel.js'));
+    return join(fixtureRootPath, fixture, 'webpack.config.babel.js');
+  }
+  catch (_) {}
+  return join(fixtureRootPath, fixture, 'webpack.config.js');
+};
+
+const run = () => {
+  let exitTimeout = -1;
+
+  process.on('message', job => {
+    clearTimeout(exitTimeout);
+    const webpackConfig = loadFreshConfig(fixtureWebpackConfigPath(job.fixture));
+    webpackConfig.plugins = webpackConfig.plugins || [];
+    webpackConfig.plugins.push({
+      apply(compiler) {
+        compiler.plugin('jest-webpack-done', ({success}) => {
+          process.send({id: job.id, success});
+          exitTimeout = setTimeout(() => process.exit(), 100);
+        });
+      },
+    });
+    process.chdir(join(fixtureRootPath, job.fixture));
+    jestWebpack(job.args || [], webpackConfig);
+  });
+
+  exitTimeout = setTimeout(() => process.exit(), 5000);
+};
+
+run();

--- a/src/entry-reference-plugin.js
+++ b/src/entry-reference-plugin.js
@@ -82,7 +82,7 @@ class EntryReferencePlugin {
             else {
               callback(null, new ReferenceEntryModule(data, dep));
             }
-          });
+          }, data.resource.split('?')[1] === '__jest_webpack_isEntry');
         });
       });
 

--- a/src/shared-data.js
+++ b/src/shared-data.js
@@ -224,7 +224,8 @@ class SharedData {
       ) ||
       isEntry &&
       this.manifest &&
-      this.manifest[resource]
+      this.manifest[resource] &&
+      this.manifest[resource].transforms.find(transform => transform.isEntry)
     ) {
       this.fulfilledManifest[resource] = this.fulfilledManifest[resource] || {
         transforms: [],
@@ -257,7 +258,7 @@ class SharedData {
         .dependencies.forEach(dep => {
           const depSplit = dep.split('!');
           const resource = depSplit[depSplit.length - 1];
-          this.compileModule(dep, resource.split('?')[0], () => {});
+          this.compileModule(dep, resource.split('?')[0], () => {}, resource.split('?')[1] === '__jest_webpack_isEntry');
         });
       }
       return callback(null, {


### PR DESCRIPTION
Tests were taking too long since they had to create a new process for each one, meaning node needs to parse and compile all of the javascript for webpack and jest. For users, this only happens once so it isn't as noticable as it happening for every test added to jest-webpack.