### PR TITLE
#14 - Support flags for webpack 

### DIFF
--- a/jest-webpack.js
+++ b/jest-webpack.js
@@ -44,6 +44,7 @@ function run(argv, webpackConfig) {
     webpackConfig = tryRequire(
       function() {return require('webpack/bin/convert-argv');},
       function() {return require('webpack-cli/bin/convert-argv');}
+      function() {return require('webpack-cli/bin/utils/convert-argv');}
     )(
       webpackYargs, webpackArgv
     );

--- a/jest-webpack.js
+++ b/jest-webpack.js
@@ -77,7 +77,7 @@ function run(argv, webpackConfig) {
     process.env.NODE_ENV = 'test';
   }
 
-  main(argv, webpackConfig);
+  main(jestArgvPortion, webpackConfig);
 }
 
 if (process.mainModule === module) {

--- a/jest-webpack.js
+++ b/jest-webpack.js
@@ -37,6 +37,7 @@ function run(argv, webpackConfig) {
     var webpackYargs = require('yargs/yargs')([]);
     tryRequire(
       function() {return require('webpack/bin/config-yargs');},
+      function() {return require('webpack-cli/bin/config/config-yargs');},
       function() {return require('webpack-cli/bin/config-yargs');}
     )(webpackYargs);
     var webpackArgv = webpackYargs.parse(webpackArgvPortion);

--- a/jest-webpack.js
+++ b/jest-webpack.js
@@ -43,7 +43,7 @@ function run(argv, webpackConfig) {
     var webpackArgv = webpackYargs.parse(webpackArgvPortion);
     webpackConfig = tryRequire(
       function() {return require('webpack/bin/convert-argv');},
-      function() {return require('webpack-cli/bin/convert-argv');}
+      function() {return require('webpack-cli/bin/convert-argv');},
       function() {return require('webpack-cli/bin/utils/convert-argv');}
     )(
       webpackYargs, webpackArgv


### PR DESCRIPTION
I tried to specify a different webpack config file by calling `jest-webpack --webpack --config webpack.tests.config.js`.

That did not work because jest also recognizes the `--config` option and complains about an invalid config.

This commit fixes the issue for me, but I am not sure it won't break anything else.