### PR TITLE
Also look for webpack-cli config-yargs in new location

### DIFF
--- a/jest-webpack.js
+++ b/jest-webpack.js
@@ -37,6 +37,7 @@ function run(argv, webpackConfig) {
     var webpackYargs = require('yargs/yargs')([]);
     tryRequire(
       function() {return require('webpack/bin/config-yargs');},
+      function() {return require('webpack-cli/bin/config/config-yargs');},
       function() {return require('webpack-cli/bin/config-yargs');}
     )(webpackYargs);
     var webpackArgv = webpackYargs.parse(webpackArgvPortion);


### PR DESCRIPTION
config-yargs.js within webpack-cli has been moved inside an extra directory called config. This pull request allows jest-webpack to find it.

Should fix some or all of Issues #27 #38 #40